### PR TITLE
Updated README.md YouCompleteMe Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ git clone https://github.com/rust-lang/rust.vim.git
 [YouCompleteMe](https://github.com/Valloric/YouCompleteMe) - a code-completion engine for Vim with support for C-family languages and [Rust](http://blog.jwilm.io/youcompleteme-rust)
 
 ```sh
+cd ~/.vim/bundle
 
 git clone https://github.com/Valloric/YouCompleteMe
 


### PR DESCRIPTION
In the "Install YouCompleteMe" section there is an implicit assumption that the user is still in the ~/.vim/bundle directory. If the user does not follow the guide exactly as outlined and changes directories between these sections, or if the user elects not to install syntax highlighting, this assumption could lead to errors for true beginners.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ivanceras/rust-vim-setup/4)

<!-- Reviewable:end -->
